### PR TITLE
RFC: Initial support for I/O based on DateTime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UTCDateTimes"
 uuid = "0f7cfa37-7abf-4834-b969-a8aa512401c2"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/UTCDateTimes.jl
+++ b/src/UTCDateTimes.jl
@@ -5,6 +5,13 @@ export UTCDateTime
 using Dates
 using TimeZones
 
+function __init__()
+    # same as DateTime minus AMPM
+    Dates.CONVERSION_TRANSLATIONS[UTCDateTime] = (
+        Year, Month, Day, Hour, Minute, Second, Millisecond
+    )
+end
+
 struct UTCDateTime <: Dates.AbstractDateTime
     dt::DateTime
 end
@@ -17,5 +24,6 @@ UTCDateTime(zdt::ZonedDateTime) = UTCDateTime(DateTime(zdt, Dates.UTC))
 
 include("dates.jl")
 include("timezones.jl")
+include("io.jl")
 
 end

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -57,3 +57,6 @@ Dates.guess(a::UTCDateTime, b::UTCDateTime, c) = Dates.guess(a.dt, b.dt, c)
 # rounding
 Base.trunc(utcdt::UTCDateTime, t::Type{<:Period}) = UTCDateTime(trunc(utcdt.dt, t))
 Base.floor(utcdt::UTCDateTime, p::Period) = UTCDateTime(floor(utcdt.dt, p))
+
+# parsing/formatting
+Dates.default_format(::Type{UTCDateTime}) = Dates.default_format(DateTime)

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,1 @@
+Base.print(io::IO, utcdt::UTCDateTime) = print(io, utcdt.dt)

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,0 +1,47 @@
+@testset "io" begin
+    format = Dates.default_format(UTCDateTime)
+
+    rt_tests = [
+        ("2022-11-12T01:02:03.987", UTCDateTime(2022, 11, 12, 1, 2, 3, 987)),
+        ("2022-11-12T01:02:03", UTCDateTime(2022, 11, 12, 1, 2, 3)),
+    ]
+
+    parse_tests = [
+        rt_tests...,
+        ("2022-11-12T01:02", UTCDateTime(2022, 11, 12, 1, 2)),
+        ("2022-11-12T01", UTCDateTime(2022, 11, 12, 1)),
+        ("2022-11-12", UTCDateTime(2022, 11, 12)),
+        ("2022-11", UTCDateTime(2022, 11)),
+        ("2022", UTCDateTime(2022)),
+    ]
+
+    format_tests = [
+        ("2022-11-12T01:02:03.987", UTCDateTime(2022, 11, 12, 1, 2, 3, 987)),
+        ("2022-11-12T01:02:03.0", UTCDateTime(2022, 11, 12, 1, 2, 3)),
+        ("2022-11-12T01:02:00.0", UTCDateTime(2022, 11, 12, 1, 2)),
+        ("2022-11-12T01:00:00.0", UTCDateTime(2022, 11, 12, 1)),
+        ("2022-11-12T00:00:00.0", UTCDateTime(2022, 11, 12)),
+        ("2022-11-01T00:00:00.0", UTCDateTime(2022, 11)),
+        ("2022-01-01T00:00:00.0", UTCDateTime(2022)),
+    ]
+
+    @testset "parsing" begin
+        @testset for (str, utcdt) in parse_tests
+            @test parse(UTCDateTime, str) == utcdt
+        end
+
+        @testset for (str, utcdt) in parse_tests
+            @test parse(UTCDateTime, str, format) == utcdt
+        end
+    end
+
+    @testset "printing" begin
+        @testset for (str, utcdt) in rt_tests
+            @test sprint(print, utcdt) == str
+        end
+
+        @testset for (str, utcdt) in format_tests
+            @test Dates.format(utcdt, format) == str
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using TimeZones
     include("traits.jl")
     include("dates.jl")
     include("timezones.jl")
+    include("io.jl")
 end


### PR DESCRIPTION
This doesn't do anything to support time zone indicators, it just works with bare DateTimes to start. It uses DateTime parsing and formatting under the hood. 