### PR TITLE
Add an explicit DateTime constructor for UTCDateTime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UTCDateTimes"
 uuid = "0f7cfa37-7abf-4834-b969-a8aa512401c2"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -1,3 +1,5 @@
+DateTime(utcdt::UTCDateTime) = utcdt.dt
+
 const delegated = [
     :days,
     :hour,

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -17,6 +17,7 @@
         @test utcdt == expected
         @test Date(utcdt) == date
         @test Time(utcdt) == time
+        @test DateTime(utcdt) == dt
         @test UTCDateTime(uyear, umonth, uday, uhour, uminute, usecond, umillisecond) ==
             expected
         @test Date(UTCDateTime(uyear, umonth, uday)) == date


### PR DESCRIPTION
This seems a bit more consistent that having dependencies access `utcdt.dt`.