### PR TITLE
Rename unix2utc to unix2utcdt (matches unix2zdt)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,9 +49,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
-          file: lcov.info
+          files: lcov.info
 
   slack:
     name: Notify Slack Failure

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
-          file: lcov.info
+          files: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UTCDateTimes"
 uuid = "0f7cfa37-7abf-4834-b969-a8aa512401c2"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/UTCDateTimes.jl
+++ b/src/UTCDateTimes.jl
@@ -1,6 +1,6 @@
 module UTCDateTimes
 
-export UTCDateTime, unix2utc
+export UTCDateTime, unix2utcdt
 
 using Dates
 using TimeZones
@@ -23,12 +23,12 @@ UTCDateTime(d::Date, t::Time) = UTCDateTime(DateTime(d, t))
 UTCDateTime(zdt::ZonedDateTime) = UTCDateTime(DateTime(zdt, Dates.UTC))
 
 """
-    unix2utc(x) -> DateTime
+    unix2utcdt(x) -> DateTime
 
 Take the number of seconds since unix epoch `1970-01-01T00:00:00` and convert to the
 corresponding `UTCDateTime`.
 """
-unix2utc(x) = UTCDateTime(unix2datetime(x))
+unix2utcdt(x) = UTCDateTime(unix2datetime(x))
 
 include("dates.jl")
 include("timezones.jl")

--- a/src/UTCDateTimes.jl
+++ b/src/UTCDateTimes.jl
@@ -1,6 +1,6 @@
 module UTCDateTimes
 
-export UTCDateTime, unix2utcdt
+export UTCDateTime
 
 using Dates
 using TimeZones
@@ -22,6 +22,7 @@ UTCDateTime(d::Date, t::Time) = UTCDateTime(DateTime(d, t))
 
 UTCDateTime(zdt::ZonedDateTime) = UTCDateTime(DateTime(zdt, Dates.UTC))
 
+# This was briefly exported as unix2utc; deprecation changing exported state is a challenge
 """
     unix2utcdt(x) -> DateTime
 

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -75,7 +75,7 @@
         @test convert(DateTime, utcdt) == dt
 
         timestamp = datetime2unix(DateTime(2020, 02, 02))
-        @test unix2utcdt(timestamp) == UTCDateTime(2020, 02, 02)
+        @test UTCDateTimes.unix2utcdt(timestamp) == UTCDateTime(2020, 02, 02)
     end
 
     @testset "Comparisons and arithmetic" begin

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -75,7 +75,7 @@
         @test convert(DateTime, utcdt) == dt
 
         timestamp = datetime2unix(DateTime(2020, 02, 02))
-        @test unix2utc(timestamp) == UTCDateTime(2020, 02, 02)
+        @test unix2utcdt(timestamp) == UTCDateTime(2020, 02, 02)
     end
 
     @testset "Comparisons and arithmetic" begin


### PR DESCRIPTION
`unix2utc` doesn't include type info in the name the way `unix2datetime` and `unix2zdt` do. 

This changes the export in a patch version but this has not been out for very long. 